### PR TITLE
Bug/no fe validation for certain inputs

### DIFF
--- a/src/components/form/MinBuyAmountInput.tsx
+++ b/src/components/form/MinBuyAmountInput.tsx
@@ -15,8 +15,8 @@ export const MinBuyAmountInput = () => {
         label={FORM_PARAMETERS[formKey].label}
         name={formKey}
         rules={{
-          required: true,
-          pattern: POSITIVE_NUMBER,
+          required: { value: true, message: 'Field is required' },
+          pattern: { value: POSITIVE_NUMBER, message: 'Invalid number' },
           validate: {
             min: (value) => value > 0 || 'Amount to buy should be positive',
           },

--- a/src/components/form/MinBuyAmountPerOrderInput.tsx
+++ b/src/components/form/MinBuyAmountPerOrderInput.tsx
@@ -14,7 +14,10 @@ export const MinBuyAmountPerOrderInput = () => {
       <Input
         label={FORM_PARAMETERS[formKey].label}
         name={formKey}
-        rules={{ required: true, pattern: POSITIVE_NUMBER }}
+        rules={{
+          required: { value: true, message: 'Field is required' },
+          pattern: { value: POSITIVE_NUMBER, message: 'Invalid number' },
+        }}
       />
       <IconTooltip tooltipText={FORM_PARAMETERS[formKey].tooltipText} />
     </InputLineContainer>

--- a/src/components/form/MinFundingThresholdInput.tsx
+++ b/src/components/form/MinFundingThresholdInput.tsx
@@ -15,8 +15,8 @@ export const MinFundingThresholdInput = () => {
         label={FORM_PARAMETERS[formKey].label}
         name={formKey}
         rules={{
-          required: true,
-          pattern: POSITIVE_NUMBER,
+          required: { value: true, message: 'Field is required' },
+          pattern: { value: POSITIVE_NUMBER, message: 'Invalid number' },
         }}
       />
       <IconTooltip tooltipText={FORM_PARAMETERS[formKey].tooltipText} />

--- a/src/components/form/MinFundingThresholdInput.tsx
+++ b/src/components/form/MinFundingThresholdInput.tsx
@@ -17,9 +17,6 @@ export const MinFundingThresholdInput = () => {
         rules={{
           required: true,
           pattern: POSITIVE_NUMBER,
-          validate: {
-            min: (value) => value > 0 || 'Minimal funding should be positive',
-          },
         }}
       />
       <IconTooltip tooltipText={FORM_PARAMETERS[formKey].tooltipText} />

--- a/src/components/form/SellAmountInput.tsx
+++ b/src/components/form/SellAmountInput.tsx
@@ -15,8 +15,8 @@ export const SellAmountInput = () => {
         label={FORM_PARAMETERS[formKey].label}
         name={formKey}
         rules={{
-          required: true,
-          pattern: POSITIVE_NUMBER,
+          required: { value: true, message: 'Field is required' },
+          pattern: { value: POSITIVE_NUMBER, message: 'Invalid number' },
           validate: {
             min: (value) => value > 0 || 'Amount to sell must be positive',
           },


### PR DESCRIPTION
Closes #34 
Closes #33 

About starting decimals with just a period, I've left the way is now, maybe we can put in another issue as low priority.
About numbers with more than 18 decimals, I couldn't make a case in which an input with > 18 decimals make the button enabled